### PR TITLE
New Feature: Player Card & Table Background Skins

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -234,3 +234,139 @@ body {
   display: inline-block; /* required for transform on inline text */
   animation: ne-glitch 4s infinite;
 }
+
+/* ─── Card skins ─────────────────────────────────────────────────────────────
+   cs-face-{key} is applied to the face-up card wrapper.
+   cs-back-{key} is applied to the face-down card wrapper.
+   Both are kept in sync per skin so the deck feels cohesive.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+/* Gold */
+.cs-face-gold {
+  background-color: #fffdf0 !important;
+  border-color: #c8960c !important;
+  box-shadow: 0 0 0 1px #d4af3740, 0 2px 6px #d4af3730 !important;
+}
+.cs-back-gold {
+  background-color: #7a5c00 !important;
+  border-color: #c8960c !important;
+}
+.cs-back-gold > div {
+  background-image: repeating-linear-gradient(
+    45deg,
+    #8a6800 0px, #8a6800 4px,
+    #7a5c00 4px, #7a5c00 8px
+  ) !important;
+  border-color: #d4af37 !important;
+}
+
+/* Midnight */
+.cs-face-midnight {
+  background-color: #0f1729 !important;
+  border-color: #3b5bdb !important;
+  box-shadow: 0 0 0 1px #3b5bdb40, 0 2px 6px #3b5bdb20 !important;
+}
+.cs-face-midnight .text-gray-900 {
+  color: #e2e8f0 !important;
+}
+.cs-face-midnight .text-red-600 {
+  color: #f87171 !important;
+}
+.cs-back-midnight {
+  background-color: #0b1021 !important;
+  border-color: #3b5bdb !important;
+}
+.cs-back-midnight > div {
+  background-image: repeating-linear-gradient(
+    45deg,
+    #1a2744 0px, #1a2744 4px,
+    #0f1a38 4px, #0f1a38 8px
+  ) !important;
+  border-color: #4c6ef5 !important;
+}
+
+/* Rose */
+.cs-face-rose {
+  background-color: #fff5f7 !important;
+  border-color: #f43f5e !important;
+  box-shadow: 0 0 0 1px #f43f5e30, 0 2px 6px #f43f5e20 !important;
+}
+.cs-back-rose {
+  background-color: #881337 !important;
+  border-color: #f43f5e !important;
+}
+.cs-back-rose > div {
+  background-image: repeating-linear-gradient(
+    45deg,
+    #9f1239 0px, #9f1239 4px,
+    #881337 4px, #881337 8px
+  ) !important;
+  border-color: #fb7185 !important;
+}
+
+/* Neon */
+@keyframes cs-neon-glow {
+  0%, 100% { box-shadow: 0 0 4px #22d3ee80, 0 0 0 1px #22d3ee60; }
+  50%       { box-shadow: 0 0 10px #22d3ee, 0 0 0 1px #22d3ee, 0 0 20px #22d3ee40; }
+}
+.cs-face-neon {
+  background-color: #0b1a1f !important;
+  border-color: #22d3ee !important;
+  animation: cs-neon-glow 2s ease-in-out infinite;
+}
+.cs-face-neon .text-gray-900 {
+  color: #e0f7fa !important;
+}
+.cs-face-neon .text-red-600 {
+  color: #f06292 !important;
+}
+.cs-back-neon {
+  background-color: #071419 !important;
+  border-color: #22d3ee !important;
+  animation: cs-neon-glow 2s ease-in-out infinite;
+}
+.cs-back-neon > div {
+  background-image: repeating-linear-gradient(
+    45deg,
+    #0d2329 0px, #0d2329 4px,
+    #071419 4px, #071419 8px
+  ) !important;
+  border-color: #67e8f9 !important;
+}
+
+/* ─── Table backgrounds ──────────────────────────────────────────────────────
+   tb-{key} replaces felt-bg on the root game table div.
+   Each uses the same radial-gradient + subtle texture pattern as felt-bg.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+/* Midnight — deep navy */
+.tb-midnight {
+  background-color: #080e1f;
+  background-image:
+    radial-gradient(ellipse at top, #0d1a40 0%, #050c1a 60%),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4'%3E%3Crect width='4' height='4' fill='%23050c1a'/%3E%3Crect x='0' y='0' width='1' height='1' fill='%230a1430' opacity='0.5'/%3E%3C/svg%3E");
+}
+
+/* Velvet — deep burgundy */
+.tb-velvet {
+  background-color: #1c0511;
+  background-image:
+    radial-gradient(ellipse at top, #2e0819 0%, #160310 60%),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4'%3E%3Crect width='4' height='4' fill='%23160310'/%3E%3Crect x='0' y='0' width='1' height='1' fill='%23240518' opacity='0.5'/%3E%3C/svg%3E");
+}
+
+/* Casino Red — classic Vegas red */
+.tb-casino {
+  background-color: #200505;
+  background-image:
+    radial-gradient(ellipse at top, #3d0808 0%, #180404 60%),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4'%3E%3Crect width='4' height='4' fill='%23180404'/%3E%3Crect x='0' y='0' width='1' height='1' fill='%23290606' opacity='0.5'/%3E%3C/svg%3E");
+}
+
+/* Ocean — cool deep teal */
+.tb-ocean {
+  background-color: #021820;
+  background-image:
+    radial-gradient(ellipse at top, #05303f 0%, #011419 60%),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4'%3E%3Crect width='4' height='4' fill='%23011419'/%3E%3Crect x='0' y='0' width='1' height='1' fill='%23042530' opacity='0.5'/%3E%3C/svg%3E");
+}

--- a/app/components/game/DealerZone.tsx
+++ b/app/components/game/DealerZone.tsx
@@ -4,9 +4,12 @@ import { getScoreDisplay, getBestValue } from "~/lib/handUtils";
 
 interface DealerZoneProps {
   hand: Hand;
+  /** Card skin key for the dealer's deck.  Null = default styling.
+   *  Reserved for future event-driven skins (e.g. "Gold Dealer" events). */
+  cardSkin?: string | null;
 }
 
-export function DealerZone({ hand }: DealerZoneProps) {
+export function DealerZone({ hand, cardSkin }: DealerZoneProps) {
   const score = getScoreDisplay(hand.cards);
   const best = getBestValue(hand.cards);
   const isBust = best > 21;
@@ -23,6 +26,7 @@ export function DealerZone({ hand }: DealerZoneProps) {
           <PlayingCard
             key={i}
             card={card}
+            skin={cardSkin}
             style={{ zIndex: i, position: "relative" }}
           />
         ))}

--- a/app/components/game/GameTable.tsx
+++ b/app/components/game/GameTable.tsx
@@ -6,6 +6,8 @@ import { BettingControls } from "./BettingControls";
 import { ActionControls } from "./ActionControls";
 import { ShoeIndicator } from "./ShoeIndicator";
 import { Countdown } from "~/components/ui/Countdown";
+import { useAuth } from "~/lib/AuthContext";
+import { tableBgClass } from "~/lib/tableBgs";
 
 const ACTIVE_PHASES: GameState["phase"][] = [
   "betting",
@@ -44,6 +46,7 @@ export function GameTable({
   chatUnreadCount = 0,
   onChatToggle,
 }: GameTableProps) {
+  const { user } = useAuth();
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const self = state.players.find((p) => p.playerId === selfPlayerId);
   const isSelfTurn = state.activePlayerId === selfPlayerId;
@@ -62,7 +65,7 @@ export function GameTable({
 
   return (
     <div
-      className="relative flex flex-col min-h-screen felt-bg"
+      className={`relative flex flex-col min-h-screen ${tableBgClass(user?.equippedTableBg)}`}
     >
       {/* Leave-table confirmation modal */}
       {showLeaveConfirm && (
@@ -164,7 +167,7 @@ export function GameTable({
 
       {/* Dealer area */}
       <div className="flex justify-center py-8">
-        <DealerZone hand={state.dealerHand} />
+        <DealerZone hand={state.dealerHand} cardSkin={state.dealerCardSkin} />
       </div>
 
       {/* Divider line */}

--- a/app/components/game/PlayerHand.tsx
+++ b/app/components/game/PlayerHand.tsx
@@ -8,9 +8,11 @@ interface PlayerHandProps {
   hand: Hand;
   isActive: boolean;
   small?: boolean;
+  /** Card skin key from the owning player. */
+  cardSkin?: string | null;
 }
 
-export function PlayerHand({ hand, isActive, small = false }: PlayerHandProps) {
+export function PlayerHand({ hand, isActive, small = false, cardSkin }: PlayerHandProps) {
   const score = getScoreDisplay(hand.cards);
   const best = getBestValue(hand.cards);
   const isBust = best > 21;
@@ -29,6 +31,7 @@ export function PlayerHand({ hand, isActive, small = false }: PlayerHandProps) {
             key={i}
             card={card}
             small={small}
+            skin={cardSkin}
             className="transition-all duration-200"
             style={{ zIndex: i }}
           />

--- a/app/components/game/PlayerSeat.tsx
+++ b/app/components/game/PlayerSeat.tsx
@@ -278,6 +278,7 @@ export function PlayerSeat({ player, activeHandId, isCurrentPlayer, isSelf, onPl
               key={hand.handId}
               hand={hand}
               isActive={isCurrentPlayer && hand.handId === activeHandId}
+              cardSkin={player.cardSkin}
             />
           ))}
         </div>

--- a/app/components/game/PlayingCard.tsx
+++ b/app/components/game/PlayingCard.tsx
@@ -1,10 +1,13 @@
 import type { Card } from "~/lib/types";
+import { cardSkinFaceClass, cardSkinBackClass } from "~/lib/cardSkins";
 
 interface PlayingCardProps {
   card: Card;
   small?: boolean;
   className?: string;
   style?: React.CSSProperties;
+  /** Card skin key from the owning player (or dealer).  Null/undefined = default styling. */
+  skin?: string | null;
 }
 
 const SUIT_SYMBOLS: Record<string, string> = {
@@ -16,9 +19,9 @@ const SUIT_SYMBOLS: Record<string, string> = {
 
 const RED_SUITS = new Set(["hearts", "diamonds"]);
 
-export function PlayingCard({ card, small = false, className = "", style }: PlayingCardProps) {
+export function PlayingCard({ card, small = false, className = "", style, skin }: PlayingCardProps) {
   if (card.faceDown) {
-    return <CardBack small={small} className={className} style={style} />;
+    return <CardBack small={small} className={className} style={style} skin={skin} />;
   }
 
   const isRed = RED_SUITS.has(card.suit);
@@ -26,12 +29,14 @@ export function PlayingCard({ card, small = false, className = "", style }: Play
   const w = small ? "w-11" : "w-14";
   const h = small ? "h-16" : "h-20";
   const text = small ? "text-sm" : "text-base";
+  const faceClass = cardSkinFaceClass(skin);
 
   return (
     <div
       className={`
         ${w} ${h} rounded-lg bg-white border border-gray-200 shadow-md
         flex flex-col justify-between p-1 select-none card-appear
+        ${faceClass}
         ${className}
       `}
       style={style}
@@ -50,15 +55,17 @@ export function PlayingCard({ card, small = false, className = "", style }: Play
   );
 }
 
-function CardBack({ small = false, className = "", style }: { small?: boolean; className?: string; style?: React.CSSProperties }) {
+function CardBack({ small = false, className = "", style, skin }: { small?: boolean; className?: string; style?: React.CSSProperties; skin?: string | null }) {
   const w = small ? "w-11" : "w-14";
   const h = small ? "h-16" : "h-20";
+  const backClass = cardSkinBackClass(skin);
 
   return (
     <div
       className={`
         ${w} ${h} rounded-lg bg-blue-900 border border-blue-700 shadow-md
         flex items-center justify-center select-none card-appear
+        ${backClass}
         ${className}
       `}
       style={style}

--- a/app/lib/AuthContext.tsx
+++ b/app/lib/AuthContext.tsx
@@ -15,6 +15,10 @@ export interface AuthUser {
   lastDailyClaimed: string | null;
   roles: RoleInfo[];
   equippedNameEffect: string | null;
+  /** Equipped card skin key — visible to all players at the table. */
+  equippedCardSkin: string | null;
+  /** Equipped table background key — local-only, never broadcast to other players. */
+  equippedTableBg: string | null;
 }
 
 interface AuthContextValue {
@@ -34,6 +38,10 @@ interface AuthContextValue {
   updateUserProfile: (displayName: string, avatarColor: string) => void;
   /** Update local equipped name-effect state after equipping/unequipping a vanity item. */
   updateEquippedEffect: (effectKey: string | null) => void;
+  /** Update local equipped card skin state after equipping/unequipping. */
+  updateEquippedCardSkin: (skinKey: string | null) => void;
+  /** Update local equipped table background state after equipping/unequipping. */
+  updateEquippedTableBg: (bgKey: string | null) => void;
 }
 
 const AUTH_TOKEN_KEY = "bj_auth_token";
@@ -50,6 +58,8 @@ interface ServerPlayerResponse {
   lastDailyClaimed: string | null;
   roles: RoleInfo[];
   equippedNameEffect?: string | null;
+  equippedCardSkin?: string | null;
+  equippedTableBg?: string | null;
 }
 
 interface AuthApiResponse {
@@ -81,6 +91,8 @@ function serverPlayerToAuthUser(player: ServerPlayerResponse): AuthUser {
     lastDailyClaimed: player.lastDailyClaimed,
     roles: player.roles ?? [],
     equippedNameEffect: player.equippedNameEffect ?? null,
+    equippedCardSkin:   player.equippedCardSkin   ?? null,
+    equippedTableBg:    player.equippedTableBg    ?? null,
   };
 }
 
@@ -93,6 +105,9 @@ function loadStoredUser(): AuthUser | null {
     if (!parsed.roles) parsed.roles = [];
     // Migrate old entries without equippedNameEffect
     if (!("equippedNameEffect" in parsed)) parsed.equippedNameEffect = null;
+    // Migrate old entries without skin fields
+    if (!("equippedCardSkin" in parsed)) parsed.equippedCardSkin = null;
+    if (!("equippedTableBg"  in parsed)) parsed.equippedTableBg  = null;
     return parsed as unknown as AuthUser;
   } catch {
     return null;
@@ -164,8 +179,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     localStorage.setItem(AUTH_PLAYER_KEY, JSON.stringify(updated));
   }
 
+  function updateEquippedCardSkin(skinKey: string | null): void {
+    if (!user) return;
+    const updated: AuthUser = { ...user, equippedCardSkin: skinKey };
+    setUser(updated);
+    localStorage.setItem(AUTH_PLAYER_KEY, JSON.stringify(updated));
+  }
+
+  function updateEquippedTableBg(bgKey: string | null): void {
+    if (!user) return;
+    const updated: AuthUser = { ...user, equippedTableBg: bgKey };
+    setUser(updated);
+    localStorage.setItem(AUTH_PLAYER_KEY, JSON.stringify(updated));
+  }
+
   return (
-    <AuthContext.Provider value={{ user, token, login, register, logout, updateUserChips, updateUserProfile, updateEquippedEffect }}>
+    <AuthContext.Provider value={{ user, token, login, register, logout, updateUserChips, updateUserProfile, updateEquippedEffect, updateEquippedCardSkin, updateEquippedTableBg }}>
       {children}
     </AuthContext.Provider>
   );

--- a/app/lib/cardSkins.ts
+++ b/app/lib/cardSkins.ts
@@ -1,0 +1,68 @@
+// ─── Card Skin Catalog ────────────────────────────────────────────────────────
+//
+// Each entry defines a purchasable vanity item that controls the visual style
+// of a player's cards (both face and back).  The `key` maps to CSS classes
+// `cs-face-{key}` (applied to face cards) and `cs-back-{key}` (applied to the
+// card back).  "default" is always owned for free and produces the classic
+// white/blue styling.
+
+export interface CardSkinDef {
+  key: string;
+  label: string;
+  description: string;
+  /** Chip cost.  0 = free / always owned. */
+  cost: number;
+  /**
+   * When set, this skin is role-locked: it is never purchasable and is only
+   * equippable by players who hold the named role.
+   */
+  requiredRole?: string;
+}
+
+export const CARD_SKINS: CardSkinDef[] = [
+  {
+    key:         "default",
+    label:       "Default",
+    description: "Classic white card",
+    cost:        0,
+  },
+  {
+    key:         "gold",
+    label:       "Gold",
+    description: "Gilded deck with a warm golden finish",
+    cost:        6_000,
+  },
+  {
+    key:         "midnight",
+    label:       "Midnight",
+    description: "Deep navy cards with silver accents",
+    cost:        8_000,
+  },
+  {
+    key:         "rose",
+    label:       "Rose",
+    description: "Soft rose and blush tones",
+    cost:        8_000,
+  },
+  {
+    key:         "neon",
+    label:       "Neon",
+    description: "Electric cyan glow on dark slate",
+    cost:        12_000,
+  },
+];
+
+/** Set of all valid skin keys, for server-side validation. */
+export const CARD_SKIN_KEYS = new Set(CARD_SKINS.map((s) => s.key));
+
+/** Returns the CSS class for the card face, or "" for default. */
+export function cardSkinFaceClass(key: string | null | undefined): string {
+  if (!key || key === "default") return "";
+  return `cs-face-${key}`;
+}
+
+/** Returns the CSS class for the card back, or "" for default. */
+export function cardSkinBackClass(key: string | null | undefined): string {
+  if (!key || key === "default") return "";
+  return `cs-back-${key}`;
+}

--- a/app/lib/tableBgs.ts
+++ b/app/lib/tableBgs.ts
@@ -1,0 +1,62 @@
+// ─── Table Background Catalog ─────────────────────────────────────────────────
+//
+// Each entry defines a purchasable vanity item that controls the table felt
+// background.  Table backgrounds are LOCAL-ONLY — only the equipping player
+// sees their own background; other players are unaffected.
+//
+// The `key` maps to either the special value "default" (which resolves to the
+// existing `felt-bg` class) or to a CSS class `tb-{key}` defined in app.css.
+
+export interface TableBgDef {
+  key: string;
+  label: string;
+  description: string;
+  /** Chip cost.  0 = free / always owned. */
+  cost: number;
+  requiredRole?: string;
+}
+
+export const TABLE_BGS: TableBgDef[] = [
+  {
+    key:         "default",
+    label:       "Felt Green",
+    description: "Classic casino green felt",
+    cost:        0,
+  },
+  {
+    key:         "midnight",
+    label:       "Midnight",
+    description: "Deep navy blue felt",
+    cost:        5_000,
+  },
+  {
+    key:         "velvet",
+    label:       "Velvet",
+    description: "Rich burgundy velvet",
+    cost:        5_000,
+  },
+  {
+    key:         "casino",
+    label:       "Casino Red",
+    description: "Classic Vegas red felt",
+    cost:        7_000,
+  },
+  {
+    key:         "ocean",
+    label:       "Ocean",
+    description: "Cool deep-sea teal",
+    cost:        7_000,
+  },
+];
+
+/** Set of all valid background keys, for server-side validation. */
+export const TABLE_BG_KEYS = new Set(TABLE_BGS.map((b) => b.key));
+
+/**
+ * Returns the CSS class for the given table background key.
+ * "default" (or null/undefined) resolves to the built-in `felt-bg` class.
+ */
+export function tableBgClass(key: string | null | undefined): string {
+  if (!key || key === "default") return "felt-bg";
+  return `tb-${key}`;
+}

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -103,6 +103,8 @@ export interface Player {
   avatarColor: string;
   /** Equipped vanity name-effect key, or null for default white text. */
   nameEffect: string | null;
+  /** Equipped card skin key, or null for the classic white/blue default. Visible to all players at the table. */
+  cardSkin: string | null;
 }
 
 // ─── Game Settings ─────────────────────────────────────────────────────────────
@@ -155,6 +157,11 @@ export interface GameState {
   roundNumber: number;
   settings: GameSettings;
   hiLoCount: number | null;
+  /**
+   * Card skin key applied to the dealer's deck.  Always `null` under normal play.
+   * Reserved for a future event system (e.g. "Gold Dealer" double-payout event).
+   */
+  dealerCardSkin: string | null;
 }
 
 // ─── Chat ─────────────────────────────────────────────────────────────────────

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -6,6 +6,9 @@ import { DisplayName } from "~/components/ui/DisplayName";
 import { useAuth } from "~/lib/AuthContext";
 import { AVATAR_COLORS } from "~/lib/usePlayer";
 import { NAME_EFFECTS, nameEffectClass, type NameEffectDef } from "~/lib/nameEffects";
+import { CARD_SKINS, cardSkinFaceClass, cardSkinBackClass, type CardSkinDef } from "~/lib/cardSkins";
+import { TABLE_BGS, tableBgClass, type TableBgDef } from "~/lib/tableBgs";
+import { PlayingCard } from "~/components/game/PlayingCard";
 
 export function meta() {
   return [{ title: "Account Settings — Blackjack" }];
@@ -21,9 +24,19 @@ interface VanityState {
   error: string;
 }
 
+// ─── Skin shop state ──────────────────────────────────────────────────────────
+
+interface SkinShopState {
+  owned: string[];
+  equipped: string | null;
+  loading: boolean;
+  actionLoading: string | null;
+  error: string;
+}
+
 export default function Settings() {
   const navigate = useNavigate();
-  const { user, token, updateUserProfile, updateEquippedEffect, updateUserChips } = useAuth();
+  const { user, token, updateUserProfile, updateEquippedEffect, updateUserChips, updateEquippedCardSkin, updateEquippedTableBg } = useAuth();
 
   if (!user) return <Navigate to="/login" replace />;
 
@@ -56,6 +69,106 @@ export default function Settings() {
       })
       .catch(() => {
         setVanity((v) => ({ ...v, loading: false, error: "Couldn't load name effects" }));
+      });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ─── Card skin shop ────────────────────────────────────────────────────────
+  const [cardSkins, setCardSkins] = useState<SkinShopState>({
+    owned:         [],
+    equipped:      user?.equippedCardSkin ?? null,
+    loading:       true,
+    actionLoading: null,
+    error:         "",
+  });
+
+  useEffect(() => {
+    fetch("/api/vanity/card-skins", {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : Promise.reject()))
+      .then((data: { owned: string[]; equipped: string | null }) => {
+        setCardSkins((v) => ({ ...v, owned: data.owned, equipped: data.equipped, loading: false }));
+      })
+      .catch(() => {
+        setCardSkins((v) => ({ ...v, loading: false, error: "Couldn't load card skins" }));
+      });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function ownsSkin(state: SkinShopState, key: string): boolean {
+    return key === "default" || state.owned.includes(key);
+  }
+
+  async function handlePurchaseSkin(
+    setState: React.Dispatch<React.SetStateAction<SkinShopState>>,
+    skin: CardSkinDef | TableBgDef,
+    endpoint: string
+  ) {
+    setState((v) => ({ ...v, actionLoading: skin.key, error: "" }));
+    try {
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ skinKey: skin.key }),
+      });
+      const data = (await res.json()) as { chips?: number; error?: string };
+      if (!res.ok) {
+        setState((v) => ({ ...v, actionLoading: null, error: data.error ?? "Purchase failed" }));
+        return;
+      }
+      setState((v) => ({ ...v, owned: [...v.owned, skin.key], actionLoading: null }));
+      if (data.chips != null) updateUserChips(data.chips);
+    } catch {
+      setState((v) => ({ ...v, actionLoading: null, error: "Network error" }));
+    }
+  }
+
+  async function handleEquipSkin(
+    setState: React.Dispatch<React.SetStateAction<SkinShopState>>,
+    skinKey: string | null,
+    endpoint: string,
+    onSuccess: (key: string | null) => void
+  ) {
+    const key = skinKey === "default" ? null : skinKey;
+    setState((v) => ({ ...v, actionLoading: skinKey ?? "default", error: "" }));
+    try {
+      const res = await fetch(endpoint, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ skinKey: key }),
+      });
+      const data = (await res.json()) as { skinKey: string | null; error?: string };
+      if (!res.ok) {
+        setState((v) => ({ ...v, actionLoading: null, error: data.error ?? "Equip failed" }));
+        return;
+      }
+      setState((v) => ({ ...v, equipped: data.skinKey, actionLoading: null }));
+      onSuccess(data.skinKey);
+    } catch {
+      setState((v) => ({ ...v, actionLoading: null, error: "Network error" }));
+    }
+  }
+
+  // ─── Table background shop ─────────────────────────────────────────────────
+  const [tableBgs, setTableBgs] = useState<SkinShopState>({
+    owned:         [],
+    equipped:      user?.equippedTableBg ?? null,
+    loading:       true,
+    actionLoading: null,
+    error:         "",
+  });
+
+  useEffect(() => {
+    fetch("/api/vanity/table-bgs", {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : Promise.reject()))
+      .then((data: { owned: string[]; equipped: string | null }) => {
+        setTableBgs((v) => ({ ...v, owned: data.owned, equipped: data.equipped, loading: false }));
+      })
+      .catch(() => {
+        setTableBgs((v) => ({ ...v, loading: false, error: "Couldn't load backgrounds" }));
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -386,6 +499,188 @@ export default function Settings() {
             </button>
           )}
         </div>
+
+        {/* ── Card Skins shop ── */}
+        <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 flex flex-col gap-4">
+          <div>
+            <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Card Skins</h2>
+            <p className="text-xs text-gray-600 mt-1">
+              Style your deck. Other players can see your card skin at the table.
+            </p>
+          </div>
+
+          {/* Preview */}
+          <div className="flex items-center gap-3 py-1">
+            <PlayingCard
+              card={{ suit: "spades", rank: "A", faceDown: false }}
+              skin={cardSkins.equipped}
+              small
+            />
+            <PlayingCard
+              card={{ suit: "hearts", rank: "K", faceDown: true }}
+              skin={cardSkins.equipped}
+              small
+            />
+            <span className="text-xs text-gray-500 ml-1">
+              {CARD_SKINS.find((s) => s.key === (cardSkins.equipped ?? "default"))?.label ?? "Default"}
+            </span>
+          </div>
+
+          {cardSkins.error && <p className="text-sm text-red-400">{cardSkins.error}</p>}
+
+          {cardSkins.loading ? (
+            <p className="text-sm text-gray-500 text-center py-4">Loading…</p>
+          ) : (
+            <div className="grid grid-cols-2 gap-2">
+              {CARD_SKINS.map((skin) => {
+                const owned    = ownsSkin(cardSkins, skin.key);
+                const equipped = cardSkins.equipped === skin.key
+                               || (skin.key === "default" && !cardSkins.equipped);
+                const isActing = cardSkins.actionLoading === skin.key;
+
+                return (
+                  <div
+                    key={skin.key}
+                    className={`
+                      flex flex-col gap-2 p-3 rounded-xl border transition-colors
+                      ${equipped
+                        ? "border-emerald-500/50 bg-emerald-950/30"
+                        : "border-gray-700/60 bg-gray-800/40"}
+                    `}
+                  >
+                    {/* Mini card preview */}
+                    <div className="flex gap-1">
+                      <div className={`w-6 h-8 rounded border text-[8px] font-bold flex flex-col justify-between p-0.5 leading-none select-none ${cardSkinFaceClass(skin.key) || "bg-white border-gray-200 text-gray-900"}`}>
+                        <span>A</span><span>♠</span>
+                      </div>
+                      <div className={`w-6 h-8 rounded border flex items-center justify-center select-none ${cardSkinBackClass(skin.key) || "bg-blue-900 border-blue-700"}`}>
+                        <div className="w-full h-full rounded m-px" style={!cardSkinBackClass(skin.key) ? { backgroundImage: "repeating-linear-gradient(45deg,#1e3a5f 0,#1e3a5f 2px,#1a3355 2px,#1a3355 4px)" } : undefined} />
+                      </div>
+                    </div>
+
+                    <p className="text-xs font-semibold text-white">{skin.label}</p>
+                    <p className="text-xs text-gray-500 leading-tight">{skin.description}</p>
+
+                    {equipped ? (
+                      <span className="text-xs font-semibold text-emerald-400">✓ Equipped</span>
+                    ) : owned ? (
+                      <button
+                        onClick={() => handleEquipSkin(setCardSkins, skin.key, "/api/vanity/card-skins/equip", updateEquippedCardSkin)}
+                        disabled={!!cardSkins.actionLoading}
+                        className="text-xs font-semibold text-gray-300 hover:text-white transition-colors disabled:opacity-50 text-left"
+                      >
+                        {isActing ? "Equipping…" : "Equip"}
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => handlePurchaseSkin(setCardSkins, skin, "/api/vanity/card-skins/purchase")}
+                        disabled={!!cardSkins.actionLoading || (user?.chips ?? 0) < skin.cost}
+                        className="text-xs font-semibold text-yellow-400 hover:text-yellow-300 transition-colors disabled:opacity-50 text-left"
+                      >
+                        {isActing ? "Buying…" : `${skin.cost.toLocaleString()} chips`}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {cardSkins.equipped && (
+            <button
+              onClick={() => handleEquipSkin(setCardSkins, null, "/api/vanity/card-skins/equip", updateEquippedCardSkin)}
+              disabled={!!cardSkins.actionLoading}
+              className="text-xs text-gray-600 hover:text-gray-400 transition-colors self-center disabled:opacity-50"
+            >
+              {cardSkins.actionLoading ? "Removing…" : "Remove skin"}
+            </button>
+          )}
+        </div>
+
+        {/* ── Table Backgrounds shop ── */}
+        <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 flex flex-col gap-4">
+          <div>
+            <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Table Backgrounds</h2>
+            <p className="text-xs text-gray-600 mt-1">
+              Customize your felt. Only you can see your table background.
+            </p>
+          </div>
+
+          {/* Preview */}
+          <div
+            className={`h-14 rounded-xl border border-white/10 transition-all ${tableBgClass(tableBgs.equipped)}`}
+          >
+            <div className="flex items-center justify-end h-full px-3">
+              <span className="text-xs text-white/40 font-medium">
+                {TABLE_BGS.find((b) => b.key === (tableBgs.equipped ?? "default"))?.label ?? "Default"}
+              </span>
+            </div>
+          </div>
+
+          {tableBgs.error && <p className="text-sm text-red-400">{tableBgs.error}</p>}
+
+          {tableBgs.loading ? (
+            <p className="text-sm text-gray-500 text-center py-4">Loading…</p>
+          ) : (
+            <div className="grid grid-cols-2 gap-2">
+              {TABLE_BGS.map((bg) => {
+                const owned    = ownsSkin(tableBgs, bg.key);
+                const equipped = tableBgs.equipped === bg.key
+                               || (bg.key === "default" && !tableBgs.equipped);
+                const isActing = tableBgs.actionLoading === bg.key;
+
+                return (
+                  <div
+                    key={bg.key}
+                    className={`
+                      flex flex-col gap-2 p-3 rounded-xl border transition-colors
+                      ${equipped
+                        ? "border-emerald-500/50 bg-emerald-950/30"
+                        : "border-gray-700/60 bg-gray-800/40"}
+                    `}
+                  >
+                    {/* Swatch */}
+                    <div className={`h-8 rounded-lg border border-white/10 ${tableBgClass(bg.key)}`} />
+
+                    <p className="text-xs font-semibold text-white">{bg.label}</p>
+                    <p className="text-xs text-gray-500 leading-tight">{bg.description}</p>
+
+                    {equipped ? (
+                      <span className="text-xs font-semibold text-emerald-400">✓ Equipped</span>
+                    ) : owned ? (
+                      <button
+                        onClick={() => handleEquipSkin(setTableBgs, bg.key, "/api/vanity/table-bgs/equip", updateEquippedTableBg)}
+                        disabled={!!tableBgs.actionLoading}
+                        className="text-xs font-semibold text-gray-300 hover:text-white transition-colors disabled:opacity-50 text-left"
+                      >
+                        {isActing ? "Equipping…" : "Equip"}
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => handlePurchaseSkin(setTableBgs, bg, "/api/vanity/table-bgs/purchase")}
+                        disabled={!!tableBgs.actionLoading || (user?.chips ?? 0) < bg.cost}
+                        className="text-xs font-semibold text-yellow-400 hover:text-yellow-300 transition-colors disabled:opacity-50 text-left"
+                      >
+                        {isActing ? "Buying…" : `${bg.cost.toLocaleString()} chips`}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {tableBgs.equipped && (
+            <button
+              onClick={() => handleEquipSkin(setTableBgs, null, "/api/vanity/table-bgs/equip", updateEquippedTableBg)}
+              disabled={!!tableBgs.actionLoading}
+              className="text-xs text-gray-600 hover:text-gray-400 transition-colors self-center disabled:opacity-50"
+            >
+              {tableBgs.actionLoading ? "Removing…" : "Remove background"}
+            </button>
+          )}
+        </div>
+
       </div>
     </div>
   );

--- a/server/GameRoom.ts
+++ b/server/GameRoom.ts
@@ -91,7 +91,8 @@ export class GameRoom {
     avatarColor: string,
     initialChips: number,
     roles: RoleInfo[] = [],
-    nameEffect: string | null = null
+    nameEffect: string | null = null,
+    cardSkin: string | null = null
   ): { success: boolean; error?: string } {
     if (this.playerCount >= MAX_PLAYERS) {
       return { success: false, error: "Room is full" };
@@ -125,6 +126,7 @@ export class GameRoom {
       isHost,
       avatarColor,
       nameEffect,
+      cardSkin,
     };
 
     this.machine.addPlayer(player);

--- a/server/GameStateMachine.ts
+++ b/server/GameStateMachine.ts
@@ -139,6 +139,7 @@ export class GameStateMachine {
       roundNumber: 0,
       settings,
       hiLoCount: null,
+      dealerCardSkin: null,
     };
   }
 

--- a/server/db/SkinsRepository.ts
+++ b/server/db/SkinsRepository.ts
@@ -1,0 +1,102 @@
+import { eq, and } from "drizzle-orm";
+import { db } from "./client.js";
+import { players, playerOwnedSkins } from "./schema.js";
+
+export type SkinType = "card" | "table-bg";
+
+// ─── Queries ─────────────────────────────────────────────────────────────────
+
+/** Returns the skin keys owned by a player for a given skin type (never includes "default"). */
+export async function getOwnedSkins(playerId: string, skinType: SkinType): Promise<string[]> {
+  const rows = await db
+    .select({ skinKey: playerOwnedSkins.skinKey })
+    .from(playerOwnedSkins)
+    .where(
+      and(
+        eq(playerOwnedSkins.playerId, playerId),
+        eq(playerOwnedSkins.skinType, skinType),
+      ),
+    );
+  return rows.map((r) => r.skinKey);
+}
+
+/** Returns the currently equipped skin key for the given type, or null if none. */
+export async function getEquippedSkin(playerId: string, skinType: SkinType): Promise<string | null> {
+  const [row] = await db
+    .select({
+      equippedCardSkin: players.equippedCardSkin,
+      equippedTableBg:  players.equippedTableBg,
+    })
+    .from(players)
+    .where(eq(players.id, playerId));
+
+  if (!row) return null;
+  return skinType === "card"
+    ? (row.equippedCardSkin ?? null)
+    : (row.equippedTableBg  ?? null);
+}
+
+// ─── Mutations ────────────────────────────────────────────────────────────────
+
+/**
+ * Atomically deducts `cost` chips from the player and records skin ownership.
+ * Returns the new chip total on success.
+ */
+export async function purchaseSkin(
+  playerId: string,
+  skinType: SkinType,
+  skinKey: string,
+  cost: number,
+): Promise<{ success: boolean; chips?: number; error?: string }> {
+  return db.transaction(async (tx) => {
+    const [player] = await tx
+      .select({ chips: players.chips })
+      .from(players)
+      .where(eq(players.id, playerId));
+
+    if (!player) return { success: false, error: "Player not found" };
+    if (player.chips < cost) return { success: false, error: "Not enough chips" };
+
+    // Guard against double-purchase
+    const [existing] = await tx
+      .select({ skinKey: playerOwnedSkins.skinKey })
+      .from(playerOwnedSkins)
+      .where(
+        and(
+          eq(playerOwnedSkins.playerId, playerId),
+          eq(playerOwnedSkins.skinType, skinType),
+          eq(playerOwnedSkins.skinKey, skinKey),
+        ),
+      );
+    if (existing) return { success: false, error: "Already owned" };
+
+    const newChips = player.chips - cost;
+    await tx
+      .update(players)
+      .set({ chips: newChips, updatedAt: new Date() })
+      .where(eq(players.id, playerId));
+
+    await tx.insert(playerOwnedSkins).values({ playerId, skinType, skinKey });
+
+    return { success: true, chips: newChips };
+  });
+}
+
+/**
+ * Sets the player's equipped skin for a given type.  Pass `null` to revert to default.
+ * The caller is responsible for verifying ownership before calling this.
+ */
+export async function equipSkin(
+  playerId: string,
+  skinType: SkinType,
+  skinKey: string | null,
+): Promise<void> {
+  const field = skinType === "card"
+    ? { equippedCardSkin: skinKey, updatedAt: new Date() }
+    : { equippedTableBg:  skinKey, updatedAt: new Date() };
+
+  await db
+    .update(players)
+    .set(field)
+    .where(eq(players.id, playerId));
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -8,6 +8,8 @@ export const players = pgTable("players", {
   displayName: varchar("display_name", { length: 50 }).notNull(),
   avatarColor: varchar("avatar_color", { length: 20 }).notNull().default("#10B981"),
   equippedNameEffect: varchar("equipped_name_effect", { length: 30 }),
+  equippedCardSkin:   varchar("equipped_card_skin",   { length: 30 }),
+  equippedTableBg:    varchar("equipped_table_bg",    { length: 30 }),
   chips: integer("chips").notNull().default(2500),
   lastDailyClaimed: date("last_daily_claimed"),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
@@ -95,6 +97,20 @@ export const playerOwnedEffects = pgTable("player_owned_effects", {
   pk: primaryKey({ columns: [t.playerId, t.effectKey] }),
 }));
 
+/**
+ * Tracks which skin vanity items (card skins, table backgrounds) a player has purchased.
+ * skinType is 'card' or 'table-bg'. The skin catalog is defined in app/lib/cardSkins.ts
+ * and app/lib/tableBgs.ts — no DB table needed for the catalogs themselves.
+ */
+export const playerOwnedSkins = pgTable("player_owned_skins", {
+  playerId:   uuid("player_id").notNull().references(() => players.id, { onDelete: "cascade" }),
+  skinType:   varchar("skin_type", { length: 20 }).notNull(), // 'card' | 'table-bg'
+  skinKey:    varchar("skin_key",  { length: 30 }).notNull(),
+  acquiredAt: timestamp("acquired_at", { withTimezone: true }).defaultNow().notNull(),
+}, (t) => ({
+  pk: primaryKey({ columns: [t.playerId, t.skinType, t.skinKey] }),
+}));
+
 export type Player                  = typeof players.$inferSelect;
 export type NewPlayer               = typeof players.$inferInsert;
 export type PlayerStats             = typeof playerStats.$inferSelect;
@@ -102,4 +118,5 @@ export type ChatMessageRow          = typeof chatMessages.$inferSelect;
 export type Role                    = typeof roles.$inferSelect;
 export type PlayerRoleRow           = typeof playerRoles.$inferSelect;
 export type PlayerOwnedEffectRow    = typeof playerOwnedEffects.$inferSelect;
+export type PlayerOwnedSkinRow      = typeof playerOwnedSkins.$inferSelect;
 export type PlayerAchievementRow    = typeof playerAchievements.$inferSelect;

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,6 +19,9 @@ import * as achievementRepo from "./db/AchievementRepository.js";
 import * as achievementEngine from "./achievements/AchievementEngine.js";
 import { ACHIEVEMENTS, ACHIEVEMENT_MAP } from "./achievements/definitions.js";
 import { NAME_EFFECT_KEYS, NAME_EFFECTS } from "../app/lib/nameEffects.js";
+import * as skinsRepo from "./db/SkinsRepository.js";
+import { CARD_SKIN_KEYS, CARD_SKINS } from "../app/lib/cardSkins.js";
+import { TABLE_BG_KEYS, TABLE_BGS } from "../app/lib/tableBgs.js";
 
 // ─── Express ────────────────────────────────────────────────────────────────
 
@@ -104,6 +107,9 @@ app.post("/api/auth/register", async (req, res) => {
         chips: player.chips,
         lastDailyClaimed: player.lastDailyClaimed,
         roles: playerRoles,
+        equippedNameEffect: player.equippedNameEffect ?? null,
+        equippedCardSkin:   player.equippedCardSkin   ?? null,
+        equippedTableBg:    player.equippedTableBg    ?? null,
       },
     });
   } catch (err) {
@@ -145,6 +151,9 @@ app.post("/api/auth/login", async (req, res) => {
         chips: player.chips,
         lastDailyClaimed: player.lastDailyClaimed,
         roles: playerRoles,
+        equippedNameEffect: player.equippedNameEffect ?? null,
+        equippedCardSkin:   player.equippedCardSkin   ?? null,
+        equippedTableBg:    player.equippedTableBg    ?? null,
       },
     });
   } catch (err) {
@@ -379,6 +388,146 @@ app.put("/api/vanity/name-effects/equip", requireAuth, async (req: AuthedRequest
   }
 });
 
+// ─── Skin Endpoints ───────────────────────────────────────────────────────────
+
+app.get("/api/vanity/card-skins", requireAuth, async (req: AuthedRequest, res) => {
+  try {
+    const [owned, equipped] = await Promise.all([
+      skinsRepo.getOwnedSkins(req.playerId!, "card"),
+      skinsRepo.getEquippedSkin(req.playerId!, "card"),
+    ]);
+    res.json({ catalog: CARD_SKINS, owned, equipped });
+  } catch (err) {
+    console.error("[vanity/card-skins]", err);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+app.post("/api/vanity/card-skins/purchase", requireAuth, async (req: AuthedRequest, res) => {
+  try {
+    const { skinKey } = req.body as { skinKey?: string };
+    if (!skinKey || !CARD_SKIN_KEYS.has(skinKey) || skinKey === "default") {
+      res.status(400).json({ error: "Invalid skin" });
+      return;
+    }
+    const skin = CARD_SKINS.find((s) => s.key === skinKey)!;
+    if (skin.requiredRole) {
+      res.status(400).json({ error: "This skin cannot be purchased" });
+      return;
+    }
+    const result = await skinsRepo.purchaseSkin(req.playerId!, "card", skinKey, skin.cost);
+    if (!result.success) {
+      res.status(400).json({ error: result.error });
+      return;
+    }
+    res.json({ chips: result.chips });
+  } catch (err) {
+    console.error("[vanity/card-skins/purchase]", err);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+app.put("/api/vanity/card-skins/equip", requireAuth, async (req: AuthedRequest, res) => {
+  try {
+    const { skinKey } = req.body as { skinKey?: string | null };
+    const key = !skinKey || skinKey === "default" ? null : skinKey;
+    if (key !== null) {
+      if (!CARD_SKIN_KEYS.has(key)) {
+        res.status(400).json({ error: "Invalid skin" });
+        return;
+      }
+      const skin = CARD_SKINS.find((s) => s.key === key)!;
+      if (skin.requiredRole) {
+        const playerRoles = await roleRepo.getPlayerRoles(req.playerId!);
+        if (!playerRoles.some((r) => r.name === skin.requiredRole)) {
+          res.status(403).json({ error: "You don't have access to this skin" });
+          return;
+        }
+      } else {
+        const owned = await skinsRepo.getOwnedSkins(req.playerId!, "card");
+        if (!owned.includes(key)) {
+          res.status(403).json({ error: "Skin not owned" });
+          return;
+        }
+      }
+    }
+    await skinsRepo.equipSkin(req.playerId!, "card", key);
+    res.json({ skinKey: key });
+  } catch (err) {
+    console.error("[vanity/card-skins/equip]", err);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+app.get("/api/vanity/table-bgs", requireAuth, async (req: AuthedRequest, res) => {
+  try {
+    const [owned, equipped] = await Promise.all([
+      skinsRepo.getOwnedSkins(req.playerId!, "table-bg"),
+      skinsRepo.getEquippedSkin(req.playerId!, "table-bg"),
+    ]);
+    res.json({ catalog: TABLE_BGS, owned, equipped });
+  } catch (err) {
+    console.error("[vanity/table-bgs]", err);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+app.post("/api/vanity/table-bgs/purchase", requireAuth, async (req: AuthedRequest, res) => {
+  try {
+    const { skinKey } = req.body as { skinKey?: string };
+    if (!skinKey || !TABLE_BG_KEYS.has(skinKey) || skinKey === "default") {
+      res.status(400).json({ error: "Invalid background" });
+      return;
+    }
+    const bg = TABLE_BGS.find((b) => b.key === skinKey)!;
+    if (bg.requiredRole) {
+      res.status(400).json({ error: "This background cannot be purchased" });
+      return;
+    }
+    const result = await skinsRepo.purchaseSkin(req.playerId!, "table-bg", skinKey, bg.cost);
+    if (!result.success) {
+      res.status(400).json({ error: result.error });
+      return;
+    }
+    res.json({ chips: result.chips });
+  } catch (err) {
+    console.error("[vanity/table-bgs/purchase]", err);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+app.put("/api/vanity/table-bgs/equip", requireAuth, async (req: AuthedRequest, res) => {
+  try {
+    const { skinKey } = req.body as { skinKey?: string | null };
+    const key = !skinKey || skinKey === "default" ? null : skinKey;
+    if (key !== null) {
+      if (!TABLE_BG_KEYS.has(key)) {
+        res.status(400).json({ error: "Invalid background" });
+        return;
+      }
+      const bg = TABLE_BGS.find((b) => b.key === key)!;
+      if (bg.requiredRole) {
+        const playerRoles = await roleRepo.getPlayerRoles(req.playerId!);
+        if (!playerRoles.some((r) => r.name === bg.requiredRole)) {
+          res.status(403).json({ error: "You don't have access to this background" });
+          return;
+        }
+      } else {
+        const owned = await skinsRepo.getOwnedSkins(req.playerId!, "table-bg");
+        if (!owned.includes(key)) {
+          res.status(403).json({ error: "Background not owned" });
+          return;
+        }
+      }
+    }
+    await skinsRepo.equipSkin(req.playerId!, "table-bg", key);
+    res.json({ skinKey: key });
+  } catch (err) {
+    console.error("[vanity/table-bgs/equip]", err);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
 // ─── Socket.io ───────────────────────────────────────────────────────────────
 
 type SocketData = { playerId: string; username: string };
@@ -485,7 +634,8 @@ io.on("connection", (socket: AppSocket) => {
         player.avatarColor,
         player.chips,
         playerRoles,
-        player.equippedNameEffect ?? null
+        player.equippedNameEffect ?? null,
+        player.equippedCardSkin   ?? null
       );
       if (!result.success) {
         rooms.delete(code);
@@ -528,7 +678,8 @@ io.on("connection", (socket: AppSocket) => {
         player.avatarColor,
         player.chips,
         playerRoles,
-        player.equippedNameEffect ?? null
+        player.equippedNameEffect ?? null,
+        player.equippedCardSkin   ?? null
       );
       if (!result.success) {
         callback({ success: false, error: result.error });


### PR DESCRIPTION
This PR adds the ability for players to have different card and table skins.

Card skins that players have equipped are visible to other players at their table, and each player can have a different skin equipped compared to all other players at the table.

This PR also adds support for the dealer to have card skins applied to their deck, however that is future-proofing for planned updates later.